### PR TITLE
Configure the autocomplete behaviour of password fields

### DIFF
--- a/src/login.html
+++ b/src/login.html
@@ -26,6 +26,7 @@
               type="email"
               id="email"
               required
+              autocomplete="email"
             />
           </div>
         </div>
@@ -43,6 +44,7 @@
               id="password"
               class="form-control"
               required
+              autocomplete="current-password"
             />
             <span class="input-group-text toggle">
               <i class="fa fa-eye-slash" class="password-visibility-toggle"></i>

--- a/src/partials/change-password.html
+++ b/src/partials/change-password.html
@@ -4,7 +4,7 @@
       <div class="col-lg-12 col-md-12 col-12 pade-none CreateFormCon">
         <label>Ancien mot de passe</label>
         <div class="input-group password-with-visibility">
-          <input id="oldPassword" class="form-control" type="password" required />
+          <input id="oldPassword" class="form-control" type="password" required autocomplete="current-password" />
           <span class="input-group-text toggle">
             <i class="fa fa-eye-slash" class="password-visibility-toggle"></i>
           </span>
@@ -13,7 +13,7 @@
       <div class="col-lg-12 col-md-12 col-12 pade-none CreateFormCon pb-0">
         <label>Nouveau mot de passe</label>
         <div class="input-group password-with-visibility">
-          <input id="newPassword" class="form-control" type="password" required />
+          <input id="newPassword" class="form-control" type="password" required autocomplete="off" />
           <span class="input-group-text toggle">
             <i class="fa fa-eye-slash" class="password-visibility-toggle"></i>
           </span>
@@ -27,7 +27,7 @@
       <div class="col-lg-12 col-md-12 col-12 pade-none CreateFormCon">
         <label>Confirmation nouveau mot de passe</label>
         <div class="input-group password-with-visibility">
-          <input id="confirmPassword" class="form-control" type="password" required />
+          <input id="confirmPassword" class="form-control" type="password" required autocomplete="off" />
           <span class="input-group-text toggle">
             <i class="fa fa-eye-slash" class="password-visibility-toggle"></i>
           </span>


### PR DESCRIPTION
Configure the autocomplete behaviour of password fields:
Autocomplete is activated for:
- login page: username and password
- profile -> password reset tab: current password